### PR TITLE
Add Estonian Open-EID 3.12.4 as eid-ee

### DIFF
--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -1,0 +1,22 @@
+cask 'eid-ee' do
+  version '3.12.4.1666'
+  sha256 'a5a7b2824da4efb9479e4b70a952981d41c50a75b00839d0216133b04e32b5b5'
+
+  url "https://installer.id.ee/media/osx/Open-EID_#{version}.dmg"
+  name 'Electronic identity card software for Estonia'
+  name 'eID Estonia'
+  homepage 'https://installer.id.ee/?lang=eng'
+  license :gpl
+
+  pkg 'Open-EID.pkg'
+
+  uninstall script: {
+                      executable: 'uninstall.sh',
+                      input:      %w[y],
+                    }
+
+  caveats <<-EOS.undent
+    DigiDoc3 Client and ID-card Utility are available in the App Store:
+      http://appstore.com/mac/ria
+  EOS
+end


### PR DESCRIPTION
# Electronic identity card software for Estonia

Installs the system and web browser components for authentication and digital signing.

Additional software is available from the Mac App Store (and usually installed); the package installer opens the App Store automatically and I have also included a link in the Caveats.

(Cask is named following the instructions in the homebrew-eid repository, rather than the token reference.)

### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Additionally, when **adding a new cask**:

- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-eid/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-eid/issues) where that cask was already refused.
- [ ] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
