### PR TITLE
Remove license from all casks

### DIFF
--- a/Casks/eid-be.rb
+++ b/Casks/eid-be.rb
@@ -6,7 +6,6 @@ cask 'eid-be' do
   name 'Electronic identity card software of Belgium'
   name 'eID Belgium'
   homepage 'http://eid.belgium.be/'
-  license :oss
 
   pkg 'beidbuild-signed.pkg'
 

--- a/Casks/eid-de.rb
+++ b/Casks/eid-de.rb
@@ -7,7 +7,6 @@ cask 'eid-de' do
   name 'Electronic identity card software for Germany'
   name 'eID Germany'
   homepage 'https://www.ausweisapp.bund.de/startseite/'
-  license :gratis
 
   auto_updates true
 

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -6,7 +6,6 @@ cask 'eid-ee' do
   name 'Electronic identity card software for Estonia'
   name 'eID Estonia'
   homepage 'https://installer.id.ee/?lang=eng'
-  license :gpl
 
   pkg 'Open-EID.pkg'
 

--- a/Casks/eid-lv.rb
+++ b/Casks/eid-lv.rb
@@ -7,7 +7,6 @@ cask 'eid-lv' do
   name 'Electronic identity card software for Latvia'
   name 'eID Latvia'
   homepage 'https://www.eparaksts.lv'
-  license :gratis
 
   pkg 'eparakstitajs3-distribution.pkg'
 

--- a/Casks/eid-pt.rb
+++ b/Casks/eid-pt.rb
@@ -7,7 +7,6 @@ cask 'eid-pt' do
   name 'Electronic identity card software for Portugal'
   name 'eID Portugal'
   homepage 'https://www.cartaodecidadao.pt/'
-  license :gratis
 
   pkg 'Cartao_de_Cidadao.pkg'
 


### PR DESCRIPTION
> @reitermarkus: Every cask has a license stanza, which is, and never was, used for anything.

So, I remove all license stanza from all casks and documentation.

discussion from here: https://github.com/caskroom/homebrew-cask/issues/16692 and https://github.com/caskroom/homebrew-cask/issues/17437