### PR TITLE
Update eid-de to 1.10.1

### DIFF
--- a/Casks/eid-de.rb
+++ b/Casks/eid-de.rb
@@ -1,6 +1,6 @@
 cask 'eid-de' do
-  version '1.8.0'
-  sha256 '54c3e259508355cebb2929822aec7f050981959fe466888de47e7cc9992bf336'
+  version '1.10.1'
+  sha256 'fa4ea0686df725a9c770e3fe054bee4b117f2a0376e477d0752a01f0d2273bca'
 
   url "https://www.ausweisapp.bund.de/uploads/tx_ausweisdownloads/AusweisApp2-#{version}.dmg"
   name 'AusweisApp2'


### PR DESCRIPTION
I updated the formula over the web interface, so I couldn't do any of these checks:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.