### PR TITLE
Update eid-pt to 2.4.0

### DIFF
--- a/Casks/eid-pt.rb
+++ b/Casks/eid-pt.rb
@@ -1,14 +1,19 @@
 cask 'eid-pt' do
-  version '1.61.0'
-  sha256 '050bb6d4ec5a6396688e93b6e73fa8953c6e51ceef196258af9636a6ca776982'
+  version '2.4.0'
+  sha256 '977b67f6a7f80af59013cefc9ae8121ddb07957b2793c0e90c9071cd700718bb'
 
-  url "https://www.autenticacao.gov.pt/documents/10179/11955/Aplica%C3%A7%C3%A3o+de+Cart%C3%A3o+de+Cidad%C3%A3o+%28MAC+-+OSX+Sierra%29%20%28v#{version}%29/d6b5592f-106b-4aa0-816d-8f07eba8d2c2"
+  url "https://www.autenticacao.gov.pt/documents/10179/11955/Aplica%C3%A7%C3%A3o+de+Cart%C3%A3o+de+Cidad%C3%A3o+MAC+%28v#{version}%29%20Julho+2017.pkg"
   name 'Cartão de Cidadão'
   name 'Electronic identity card software for Portugal'
   name 'eID Portugal'
   homepage 'https://www.autenticacao.gov.pt/'
 
-  pkg 'Cartao_de_Cidadao.pkg'
+  pkg "Aplicação+de+Cartão+de+Cidadão+MAC+(v#{version}) Julho+2017.pkg"
 
-  uninstall script: '/usr/local/bin/pteid_uninstall.sh'
+  uninstall pkgutil: 'pt.cartaodecidadao*',
+            signal:  [
+                       ['TERM', 'com.yourcompany.pteidgui'],
+                       ['TERM', 'com.yourcompany.pteiddialogsQTsrv'],
+                       ['TERM', 'pt.cartaodecidadao.dss'],
+                     ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

The uninstall script seems to be broken*, `pkgutil` and `signal` perform the same function.

*(tries to remove files and forget pkgs with incorrect names)