### PR TITLE
eid-it ver. 6.37.05 (new formulae)

### DIFF
--- a/Casks/eid-it-tuscany.rb
+++ b/Casks/eid-it-tuscany.rb
@@ -1,12 +1,10 @@
-cask 'eid-it' do
+cask 'eid-it-tuscany' do
   version '6.37.05'
   sha256 'a4ce3256f361a4b40b6958be599c69fedb18a42f695f207e86b64810a49746e4'
 
   url 'http://www.regione.toscana.it/documents/10180/13787134/Software+carta+1+MAC/a58c2031-449c-48cc-8c31-24c5dc2443bc'
-  name 'IDProtect Manager'
-  name 'IDProtect PINTool'
-  name 'Electronic identity card software of Italy'
-  name 'eID Italy'
+  name 'Electronic identity card software of Italy: Tuscany'
+  name 'eID Italy: Tuscany'
   homepage 'http://www.regione.toscana.it/servizi-online/servizi-sicuri/carta-sanitaria-elettronica'
 
   installer script: {

--- a/Casks/eid-it.rb
+++ b/Casks/eid-it.rb
@@ -1,0 +1,23 @@
+cask 'eid-it' do
+  version '6.37.05'
+  sha256 'a4ce3256f361a4b40b6958be599c69fedb18a42f695f207e86b64810a49746e4'
+
+  url 'http://www.regione.toscana.it/documents/10180/13787134/Software+carta+1+MAC/a58c2031-449c-48cc-8c31-24c5dc2443bc'
+  name 'IDProtect Manager'
+  name 'IDProtect PINTool'
+  name 'Electronic identity card software of Italy'
+  name 'eID Italy'
+  homepage 'http://www.regione.toscana.it/servizi-online/servizi-sicuri/carta-sanitaria-elettronica'
+
+  installer script: {
+                      executable: "#{staged_path}/IDProtectClient-6.37.05.app/Contents/MacOS/installbuilder.sh",
+                      args:       ['--unattendedmodeui', 'minimal', '--mode', 'unattended'],
+                      sudo:       true,
+                    }
+
+  uninstall script: {
+                      executable: "/Applications/IDProtectClient-#{version}/uninstall.app/Contents/MacOS/uninstall",
+                      args:       ['osx-intel', '--mode', 'unattended'],
+                      sudo:       true,
+                    }
+end

--- a/Casks/eid-it.rb
+++ b/Casks/eid-it.rb
@@ -10,14 +10,14 @@ cask 'eid-it' do
   homepage 'http://www.regione.toscana.it/servizi-online/servizi-sicuri/carta-sanitaria-elettronica'
 
   installer script: {
-                      executable: "#{staged_path}/IDProtectClient-6.37.05.app/Contents/MacOS/installbuilder.sh",
+                      executable: "#{staged_path}/IDProtectClient-#{version}.app/Contents/MacOS/installbuilder.sh",
                       args:       ['--unattendedmodeui', 'minimal', '--mode', 'unattended'],
                       sudo:       true,
                     }
 
   uninstall script: {
-                      executable: "/Applications/IDProtectClient-#{version}/uninstall.app/Contents/MacOS/uninstall",
-                      args:       ['osx-intel', '--mode', 'unattended'],
+                      executable: "/Applications/IDProtectClient-#{version}/uninstall.app/Contents/MacOS/installbuilder.sh",
+                      args:       ['--unattendedmodeui', 'minimal', '--mode', 'unattended'],
                       sudo:       true,
                     }
 end


### PR DESCRIPTION
Hello,
this formulae installs eid-it.

Unfortunately in Italy eids (called CNS) are issued by regional public offices and there are multiple versions of them.
This one is based on Tuscany public healthcare card, but I've tested It also on some other cards issued by Chamber of Commerce.

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-eid/pulls
[closed issues]: https://github.com/caskroom/homebrew-eid/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256