### PR TITLE
Update eid-pt 2.4.0: fix url & install

### DIFF
--- a/Casks/eid-pt.rb
+++ b/Casks/eid-pt.rb
@@ -2,13 +2,20 @@ cask 'eid-pt' do
   version '2.4.0'
   sha256 '977b67f6a7f80af59013cefc9ae8121ddb07957b2793c0e90c9071cd700718bb'
 
-  url "https://www.autenticacao.gov.pt/documents/10179/11955/Aplica%C3%A7%C3%A3o+de+Cart%C3%A3o+de+Cidad%C3%A3o+MAC+%28v#{version}%29%20Julho+2017.pkg"
+  url 'https://www.autenticacao.gov.pt/documents/10179/11955/Aplica%C3%A7%C3%A3o+de+Cart%C3%A3o+de+Cidad%C3%A3o+MAC+%28v2.4.0%29%20Julho+2017.pkg/50d7af60-1613-4f13-913e-1311f4c269a3'
   name 'Cartão de Cidadão'
   name 'Electronic identity card software for Portugal'
   name 'eID Portugal'
   homepage 'https://www.autenticacao.gov.pt/'
 
-  pkg "Aplicação+de+Cartão+de+Cidadão+MAC+(v#{version}) Julho+2017.pkg"
+  container type: :pkg
+
+  pkg 'eid-pt.pkg'
+
+  # This is a hack to force the file extension.
+  preflight do
+    system_command '/bin/mv', args: ['--', staged_path.join('50d7af60-1613-4f13-913e-1311f4c269a3'), staged_path.join('eid-pt.pkg')]
+  end
 
   uninstall pkgutil: 'pt.cartaodecidadao*',
             signal:  [


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

This fixes the download URL and forces the file extension.

https://github.com/caskroom/homebrew-eid/issues/31