### PR TITLE
Add eid-jp 3.0

### DIFF
--- a/Casks/eid-jp.rb
+++ b/Casks/eid-jp.rb
@@ -1,0 +1,25 @@
+cask 'eid-jp' do
+  version '03-00'
+  sha256 '41a04566520b3a63b95b39fcce4faee212d84b1509178feda39578e753a17179'
+
+  url "https://www.jpki.go.jp/client/download/101/JPKI#{version}.dmg"
+  name 'jpki'
+  name 'Electronic identity card software for Japan'
+  name 'eID Japan'
+  homepage 'https://www.jpki.go.jp/'
+
+  depends_on macos: '>= :yosemite'
+
+  pkg 'JPKIInstall.pkg'
+
+  uninstall pkgutil: 'jp.go.jpki',
+            script:  {
+                       executable: 'JPKIUninstall.command',
+                       input:      ['Y'],
+                       sudo:       true,
+                     }
+
+  caveats do
+    depends_on_java('8+')
+  end
+end


### PR DESCRIPTION
Hello. This fomulae installs Japanese eID software.

JPKI(Japanese Public Key Infrastructure) is eID system in Japan.
This system is managed by government, so all Japanese people can use it.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-eid/pulls
[closed issues]: https://github.com/caskroom/homebrew-eid/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256