### PR TITLE
Add eid-jp-myna 1.0.2

### DIFF
--- a/Casks/eid-jp-myna.rb
+++ b/Casks/eid-jp-myna.rb
@@ -1,6 +1,6 @@
 cask 'eid-jp-myna' do
-  version '1.0.2'
-  sha256 '07ca31d96628fb7bdae923aba205cc6d7197529d46f1265ff13a31483d609340'
+  version :latest
+  sha256 :no_check
 
   url 'https://img.myna.go.jp/tools/mac/MyNASetup.pkg'
   name 'MynaPortal'
@@ -8,8 +8,8 @@ cask 'eid-jp-myna' do
   name 'eID Japan MyNumber Client'
   homepage 'https://myna.go.jp/'
 
-  depends_on cask:  'eid-jp',
-             macos: '>= :mavericks'
+  depends_on cask:  'eid-jp'
+  depends_on macos: '>= :yosemite'
 
   pkg 'MyNASetup.pkg'
 

--- a/Casks/eid-jp-myna.rb
+++ b/Casks/eid-jp-myna.rb
@@ -1,0 +1,22 @@
+cask 'eid-jp-myna' do
+  version '1.0.2'
+  sha256 '07ca31d96628fb7bdae923aba205cc6d7197529d46f1265ff13a31483d609340'
+
+  url 'https://img.myna.go.jp/tools/mac/MyNASetup.pkg'
+  name 'MynaPortal'
+  name 'Electronic identity card software for Japan MyNumber'
+  name 'eID Japan MyNumber Client'
+  homepage 'https://myna.go.jp/'
+
+  depends_on cask:  'eid-jp',
+             macos: '>= :mavericks'
+
+  pkg 'MyNASetup.pkg'
+
+  uninstall pkgutil: 'jp.go.myna',
+            delete:  '/private/etc/MyNA'
+
+  caveats do
+    depends_on_java('8+')
+  end
+end


### PR DESCRIPTION
Hello. This fomulae installs Japanese eID software.

MynaPortal is new eID system in Japan since 2015.
(It's also called "My Number". But pkg name is "jp.go.myna", so I choosed it.)

This system is managed by government, so all Japanese people can use it.


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-eid/pulls
[closed issues]: https://github.com/caskroom/homebrew-eid/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
