### PR TITLE
Update eid-be to use signed version

### DIFF
--- a/Casks/eid-be.rb
+++ b/Casks/eid-be.rb
@@ -1,13 +1,13 @@
 cask 'eid-be' do
   version '4.3.5'
-  sha256 '36969084d8ddc583c8881e30df1ae0d2e04ae289b0ba1d5006c8085a2605008f'
+  sha256 'c6fc5a1eecdaee74411aa3edc498e0e0eb7d105d661272a277e985f8dc67d0b1'
 
-  url "https://eid.belgium.be/sites/default/files/software/eid-quickinstaller-#{version}.dmg"
+  url "https://eid.belgium.be/sites/default/files/software/eid-quickinstaller-#{version}-signed.dmg"
   name 'Electronic identity card software of Belgium'
   name 'eID Belgium Quickinstaller'
   homepage 'http://eid.belgium.be/'
 
-  pkg 'eID-Quickinstaller.pkg'
+  pkg 'eID-Quickinstaller-signed.pkg'
 
   uninstall pkgutil: 'be.eid.middleware'
 


### PR DESCRIPTION
Download URL, hash and .pkg filename were changed, breaking the Cask.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-eid/pulls
[closed issues]: https://github.com/caskroom/homebrew-eid/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
